### PR TITLE
Add Linear MCP server with SSE transport

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "linear-server": {
+      "transport": "sse",
+      "url": "https://mcp.linear.app/sse"
+    }
+  }
+}


### PR DESCRIPTION
Configures Linear MCP server at https://mcp.linear.app/sse using Server-Sent Events (SSE) transport.